### PR TITLE
Xbase junit dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+---
+language: java

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,18 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext.xbase.junit</artifactId>
+			<version>${xtend.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.xtext</groupId>
+			<artifactId>org.eclipse.xtext.junit4</artifactId>
+			<version>${xtend.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>
 			<version>4.12</version>
@@ -115,7 +127,7 @@
 			</plugin>
 		</plugins>
 	</build>
-	
+
 	<pluginRepositories>
 		<pluginRepository>
 			<id>Sonatype Snapshots</id>
@@ -128,7 +140,7 @@
 			</snapshots>
 		</pluginRepository>
 	</pluginRepositories>
-	
+
 	<repositories>
 		<repository>
 			<id>Sonatype Snapshots</id>


### PR DESCRIPTION
It seems that the upcoming Xtend/Xbase/Xtext versions are refactoring the JUnit support.
org.eclipse.xtend.core.compiler.batch.XtendCompilerTester which is used in the tests refers to classes now found in new dependencies. They have been added to the pom.xml file. Note that the dependencies my very well change in upcoming SNAPSHOT versions.
- travis-ci configuration has been added :)
