### PR TITLE
JsNative in inner classes; OverlayTypesByExample with support for primitive typed arrays; @ClientBundle.Source problem in ClientBundle

### DIFF
--- a/src/main/java/de/itemis/xtend/auto/gwt/ActiveAnnotationProcessorHelper.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/ActiveAnnotationProcessorHelper.xtend
@@ -1,0 +1,18 @@
+package de.itemis.xtend.auto.gwt
+
+import org.eclipse.xtend.lib.macro.CodeGenerationContext
+import org.eclipse.xtend.lib.macro.declaration.TypeDeclaration
+import org.eclipse.xtend.lib.macro.file.Path
+
+class ActiveAnnotationProcessorHelper {
+	private static def TypeDeclaration topLevelType(TypeDeclaration type) {
+		return if (type.declaringType == null) type else type.declaringType.topLevelType
+	}
+	
+	static def Path getTargetPath(TypeDeclaration type, extension CodeGenerationContext ctx) {		
+		val topLevelType = type.topLevelType
+		val unit = type.compilationUnit
+		val targetFolder = unit.filePath.targetFolder
+		return targetFolder.append(unit.sourceTypeDeclarations.findFirst[sourceType|sourceType==topLevelType].qualifiedName.replace('.','/')+".java")
+	}
+}

--- a/src/main/java/de/itemis/xtend/auto/gwt/ClientBundle.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/ClientBundle.xtend
@@ -20,6 +20,8 @@ import java.lang.annotation.ElementType
 import java.lang.annotation.Target
 import java.util.List
 import org.eclipse.xtend.lib.macro.Active
+import org.eclipse.xtend.lib.macro.CodeGenerationContext
+import org.eclipse.xtend.lib.macro.CodeGenerationParticipant
 import org.eclipse.xtend.lib.macro.RegisterGlobalsContext
 import org.eclipse.xtend.lib.macro.RegisterGlobalsParticipant
 import org.eclipse.xtend.lib.macro.TransformationContext
@@ -30,8 +32,6 @@ import org.eclipse.xtend.lib.macro.declaration.MutableAnnotationTarget
 import org.eclipse.xtend.lib.macro.declaration.MutableInterfaceDeclaration
 import org.eclipse.xtend.lib.macro.declaration.MutableMethodDeclaration
 import org.eclipse.xtend.lib.macro.declaration.TypeDeclaration
-import org.eclipse.xtend.lib.macro.CodeGenerationParticipant
-import org.eclipse.xtend.lib.macro.CodeGenerationContext
 import org.eclipse.xtend.lib.macro.file.Path
 
 @Target(ElementType.TYPE)
@@ -252,9 +252,11 @@ class CliendBundleProcessor implements RegisterGlobalsParticipant<InterfaceDecla
 	}
 	
 	override doGenerateCode(List<? extends InterfaceDeclaration> annotatedSourceElements, extension CodeGenerationContext context) {
-		val path = annotatedSourceElements.get(0).declaringType.getTargetPath(context)
-		val contents = path.contents.toString.replaceAll("@ClientBundle.Source", "@Source")
-		path.contents = contents
+		for(annotatedSourceElement: annotatedSourceElements) {
+			val path = annotatedSourceElement.declaringType.getTargetPath(context)
+			val newContents = path.contents.toString.replaceAll("@ClientBundle.Source", "@Source")
+			path.contents = newContents
+		} 
 	}
 
 	private def Path getTargetPath(TypeDeclaration type, extension CodeGenerationContext ctx) {

--- a/src/main/java/de/itemis/xtend/auto/gwt/ClientBundle.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/ClientBundle.xtend
@@ -32,7 +32,6 @@ import org.eclipse.xtend.lib.macro.declaration.MutableAnnotationTarget
 import org.eclipse.xtend.lib.macro.declaration.MutableInterfaceDeclaration
 import org.eclipse.xtend.lib.macro.declaration.MutableMethodDeclaration
 import org.eclipse.xtend.lib.macro.declaration.TypeDeclaration
-import org.eclipse.xtend.lib.macro.file.Path
 
 @Target(ElementType.TYPE)
 annotation CssResource {
@@ -253,15 +252,9 @@ class CliendBundleProcessor implements RegisterGlobalsParticipant<InterfaceDecla
 	
 	override doGenerateCode(List<? extends InterfaceDeclaration> annotatedSourceElements, extension CodeGenerationContext context) {
 		for(annotatedSourceElement: annotatedSourceElements) {
-			val path = annotatedSourceElement.declaringType.getTargetPath(context)
+			val path = ActiveAnnotationProcessorHelper::getTargetPath(annotatedSourceElement, context)
 			val newContents = path.contents.toString.replaceAll("@ClientBundle.Source", "@Source")
 			path.contents = newContents
 		} 
-	}
-
-	private def Path getTargetPath(TypeDeclaration type, extension CodeGenerationContext ctx) {
-		val unit = type.compilationUnit
-		val targetFolder = unit.filePath.targetFolder
-		return targetFolder.append(unit.sourceTypeDeclarations.findFirst[true].qualifiedName.replace('.','/')+".java")
 	}
 }

--- a/src/main/java/de/itemis/xtend/auto/gwt/JsNative.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/JsNative.xtend
@@ -61,7 +61,7 @@ class JsNativeProcessor extends AbstractMethodProcessor {
 		// We load change all contents first and later save all compilation units only once.
 		val javaUnits = new HashMap<Path, String>;
 		for(annotatedMethod: annotatedMethods) {
-			val path = annotatedMethod.declaringType.getTargetPath(context)
+			val path = ActiveAnnotationProcessorHelper::getTargetPath(annotatedMethod.declaringType, context)
 			if (javaUnits.get(path) == null) {
 				javaUnits.put(path, path.contents.toString)	
 			}
@@ -84,16 +84,5 @@ class JsNativeProcessor extends AbstractMethodProcessor {
 	
 	private def String trimTripleQuotes(String s) {
 		s.substring(3, s.length-3)
-	}
-	
-	private def TypeDeclaration topLevelType(TypeDeclaration type) {
-		return if (type.declaringType == null) type else type.declaringType.topLevelType
-	}
-	
-	private def Path getTargetPath(TypeDeclaration type, extension CodeGenerationContext ctx) {		
-		val topLevelType = type.topLevelType
-		val unit = type.compilationUnit
-		val targetFolder = unit.filePath.targetFolder
-		return targetFolder.append(unit.sourceTypeDeclarations.findFirst[sourceType|sourceType==topLevelType].qualifiedName.replace('.','/')+".java")
 	}
 }

--- a/src/main/java/de/itemis/xtend/auto/gwt/JsNative.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/JsNative.xtend
@@ -53,21 +53,20 @@ class JsNativeProcessor extends AbstractMethodProcessor {
 	}
 		
 	override doGenerateCode(List<? extends MethodDeclaration> annotatedMethods, extension CodeGenerationContext context) {
-		val path = annotatedMethods.findFirst[true].declaringType.getTargetPath(context)
+		val path = annotatedMethods.get(0).declaringType.getTargetPath(context)
 		var contents = path.contents.toString
 		
 		for(annotatedMethod: annotatedMethods) {
 			val markerStart = contents.indexOf(getUniqueMarkerCode(annotatedMethod))
-			val startIndex = contents.substring(0, markerStart).lastIndexOf('{')
-			val endIndex = contents.substring(markerStart).indexOf('}') + markerStart
-			val jsCode = annotatedMethod.body.toString.trimTripleQuotes
-			contents = contents.substring(0, startIndex)+"/*-{"+jsCode+"}-*/;"+contents.substring(endIndex+1)
+			if (markerStart > 0) {
+				val startIndex = contents.substring(0, markerStart).lastIndexOf('{')
+				val endIndex = contents.substring(markerStart).indexOf('}') + markerStart
+				val jsCode = annotatedMethod.body.toString.trimTripleQuotes
+				contents = contents.substring(0, startIndex)+"/*-{"+jsCode+"}-*/;"+contents.substring(endIndex+1)
+			}
 		}
 		
 		path.contents = contents
-		do {
-			Thread.sleep(100)
-		} while (path.contents.toString != contents)
 	}
 	
 	private def String trimTripleQuotes(String s) {
@@ -77,6 +76,6 @@ class JsNativeProcessor extends AbstractMethodProcessor {
 	def Path getTargetPath(TypeDeclaration type, extension CodeGenerationContext ctx) {
 		val unit = type.compilationUnit
 		val targetFolder = unit.filePath.targetFolder
-		return targetFolder.append(unit.sourceTypeDeclarations.findFirst[true].qualifiedName.replace('.','/')+".java")
+		return targetFolder.append(type.qualifiedName.replace('.','/')+".java")
 	}
 }

--- a/src/main/java/de/itemis/xtend/auto/gwt/JsNative.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/JsNative.xtend
@@ -76,6 +76,6 @@ class JsNativeProcessor extends AbstractMethodProcessor {
 	def Path getTargetPath(TypeDeclaration type, extension CodeGenerationContext ctx) {
 		val unit = type.compilationUnit
 		val targetFolder = unit.filePath.targetFolder
-		return targetFolder.append(type.qualifiedName.replace('.','/')+".java")
+		return targetFolder.append(unit.sourceTypeDeclarations.findFirst[true].qualifiedName.replace('.','/')+".java")
 	}
 }

--- a/src/main/java/de/itemis/xtend/auto/gwt/OverlayTypeByExample.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/OverlayTypeByExample.xtend
@@ -27,6 +27,9 @@ import org.eclipse.xtend.lib.macro.declaration.TypeReference
 import org.eclipse.xtend.lib.macro.declaration.Visibility
 
 import static extension de.itemis.xtend.auto.gwt.StaticUtils.*
+import com.google.gwt.core.client.JsArrayString
+import com.google.gwt.core.client.JsArrayBoolean
+import com.google.gwt.core.client.JsArrayNumber
 
 /**
  * Allows to implement a GWT OverlayType using a JSON example.
@@ -85,7 +88,7 @@ class OverlayTypeByExampleProcessor extends AbstractClassProcessor {
 	}
 	
 	
-	val PATTERN = Pattern.compile("public final native (.+) get(\\w+)\\(\\);")
+	val PATTERN = Pattern.compile("public final native (.+) get(\\w+)\\(\\) \\{\\s*(\\w+)\\s*\\}")
 	
 	/**
 	 * we add the Java comment containing the javascript code during code generation, since there is no way to add it using the Java model.
@@ -95,9 +98,8 @@ class OverlayTypeByExampleProcessor extends AbstractClassProcessor {
 		val targetFile = targetFolder.append(annotatedClass.qualifiedName.replace('.','/')+".java")
 		val contents = targetFile.contents
 		val matcher = PATTERN.matcher(contents)
-		targetFile.contents = matcher.replaceAll("public final native $1 get$2() /*-{ return this.$2; }-*/;")
+		targetFile.contents = matcher.replaceAll("public final native $1 get$2() /*-{ return this.$3; }-*/;")
 	}
-
 
 	static class Util {
 		extension TransformationContext ctx
@@ -122,6 +124,8 @@ class OverlayTypeByExampleProcessor extends AbstractClassProcessor {
 						native = true
 						final = true
 						returnType = getJavaType(property, classDeclaration)
+						// save the property key as body for later reference in code generation phase
+						body = '''«property.key»'''
 					]
 				}
 				
@@ -147,19 +151,26 @@ class OverlayTypeByExampleProcessor extends AbstractClassProcessor {
 					val type = currentContainer.declaredClasses.findFirst[simpleName == simpleTypeName]
 					type.newTypeReference
 				}
-				JsonPrimitive case element.isString: {
-					String.newTypeReference
-				}
-				JsonPrimitive case element.isBoolean: {
-					boolean.newTypeReference
-				}
-				JsonPrimitive case element.isNumber: {
-					if (element.asString.indexOf('.') == -1) {
-						int.newTypeReference
+				JsonPrimitive:
+					if (isArray) {
+						switch (element) {
+							case element.isString: return JsArrayString.newTypeReference
+							case element.isBoolean: return JsArrayBoolean.newTypeReference
+							case element.isNumber: return JsArrayNumber.newTypeReference
+						}
 					} else {
-						double.newTypeReference
-					}
-				}
+						switch (element) {
+							case element.isString: String.newTypeReference
+							case element.isBoolean: boolean.newTypeReference
+							case element.isNumber: {
+								if (element.asString.indexOf('.') == -1) {
+									int.newTypeReference
+								} else {
+									double.newTypeReference
+								}
+							}
+						}	
+					}				
 				default : {
 	 				currentContainer.addError("unknown element "+element)
 					throw new IllegalStateException

--- a/src/main/java/de/itemis/xtend/auto/gwt/OverlayTypeByExample.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/OverlayTypeByExample.xtend
@@ -26,8 +26,10 @@ import org.eclipse.xtend.lib.macro.RegisterGlobalsContext
 import org.eclipse.xtend.lib.macro.TransformationContext
 import org.eclipse.xtend.lib.macro.declaration.ClassDeclaration
 import org.eclipse.xtend.lib.macro.declaration.MutableClassDeclaration
+import org.eclipse.xtend.lib.macro.declaration.TypeDeclaration
 import org.eclipse.xtend.lib.macro.declaration.TypeReference
 import org.eclipse.xtend.lib.macro.declaration.Visibility
+import org.eclipse.xtend.lib.macro.file.Path
 
 import static extension de.itemis.xtend.auto.gwt.StaticUtils.*
 
@@ -94,8 +96,7 @@ class OverlayTypeByExampleProcessor extends AbstractClassProcessor {
 	 * we add the Java comment containing the javascript code during code generation, since there is no way to add it using the Java model.
 	 */
 	override doGenerateCode(ClassDeclaration annotatedClass, extension CodeGenerationContext context) {
-		val targetFolder = annotatedClass.compilationUnit.filePath.targetFolder
-		val path = targetFolder.append(annotatedClass.qualifiedName.replace('.','/')+".java")
+		val path = ActiveAnnotationProcessorHelper::getTargetPath(annotatedClass, context)
 		val contents = path.contents
 		val matcher = PATTERN.matcher(contents)
 		val newContents = matcher.replaceAll("public final native $1 get$2() /*-{ return this.$3; }-*/;")

--- a/src/main/java/de/itemis/xtend/auto/gwt/OverlayTypeByExample.xtend
+++ b/src/main/java/de/itemis/xtend/auto/gwt/OverlayTypeByExample.xtend
@@ -14,6 +14,9 @@ import com.google.gson.JsonParser
 import com.google.gson.JsonPrimitive
 import com.google.gwt.core.client.JavaScriptObject
 import com.google.gwt.core.client.JsArray
+import com.google.gwt.core.client.JsArrayBoolean
+import com.google.gwt.core.client.JsArrayNumber
+import com.google.gwt.core.client.JsArrayString
 import java.util.Map.Entry
 import java.util.regex.Pattern
 import org.eclipse.xtend.lib.macro.AbstractClassProcessor
@@ -27,9 +30,6 @@ import org.eclipse.xtend.lib.macro.declaration.TypeReference
 import org.eclipse.xtend.lib.macro.declaration.Visibility
 
 import static extension de.itemis.xtend.auto.gwt.StaticUtils.*
-import com.google.gwt.core.client.JsArrayString
-import com.google.gwt.core.client.JsArrayBoolean
-import com.google.gwt.core.client.JsArrayNumber
 
 /**
  * Allows to implement a GWT OverlayType using a JSON example.
@@ -95,10 +95,11 @@ class OverlayTypeByExampleProcessor extends AbstractClassProcessor {
 	 */
 	override doGenerateCode(ClassDeclaration annotatedClass, extension CodeGenerationContext context) {
 		val targetFolder = annotatedClass.compilationUnit.filePath.targetFolder
-		val targetFile = targetFolder.append(annotatedClass.qualifiedName.replace('.','/')+".java")
-		val contents = targetFile.contents
+		val path = targetFolder.append(annotatedClass.qualifiedName.replace('.','/')+".java")
+		val contents = path.contents
 		val matcher = PATTERN.matcher(contents)
-		targetFile.contents = matcher.replaceAll("public final native $1 get$2() /*-{ return this.$3; }-*/;")
+		val newContents = matcher.replaceAll("public final native $1 get$2() /*-{ return this.$3; }-*/;")
+		path.contents = newContents
 	}
 
 	static class Util {


### PR DESCRIPTION
I had trouble with a couple of issues in auto-gwt. These are my fixes:

JsNative:
a) The original implementation does not work for javascript methods in inner classes.
b) The original implementation did not work for xtend files that cause multiple java compilation units due to multiple toplevel type declarations.

OverlayTypesByExample:
a) The original implementation created code that uses JsArray for primitive types (e.g. JsArray<String>). It seems that gwt does not like that very much. I changed it to generate code with the dedicated types JsArrayString, JsArrayBoolean, etc. 
b) The original implementation was using the wrong property keys in the generated javascript method bodies. It used the type name, which is a toFirstUpper of the original keys. I am not a JSON expert, and the RPC seems not a 100% clear on case sensitivity. Anyhow, this caused later problems for me. 

ClientBundle:
xtend produces @ClientBundle.Source instead of @Source in the generated java files. For Gwt (or at least the eclipse plugins of gwt) this somehow makes a difference and it cannot not find the appropriate css file. In my opinion this is clearly a shortcomming of gwt, but it is far easier to change this annotation ;-). I simply made the processor a CodeGenerationParticipant as well and replaced all occurrences of @ClientBundle.Source. There is probably a better solution?
